### PR TITLE
refactor: split user profile queries

### DIFF
--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -4,17 +4,51 @@ import ProfileTabs from './_components/ProfileTabs';
 import ProfileHeader from './_components/ProfileHeader';
 import { useParams } from 'next/navigation';
 import { notFound } from 'next/navigation';
-import { useGetUserByIdQuery, Users } from '@/graphql/generated';
+import {
+  useGetUserPrivateInfoByIdQuery,
+  useGetUserPublicInfoByIdQuery,
+  Users,
+} from '@/graphql/generated';
 import UserProfileSkeleton from './_components/UserProfileSkeleton';
+import { useEffect, useState } from 'react';
 
 export default function UserProfilePage() {
   const params = useParams();
   const { userId } = params as { userId: string };
 
-  const { data, loading, error } = useGetUserByIdQuery({
-    variables: { getUserByIdId: userId! },
-    skip: !userId || typeof userId !== 'string',
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCurrentUserId(localStorage.getItem('userId'));
+  }, []);
+
+  const isOwner = currentUserId === userId;
+
+  const {
+    data: publicData,
+    loading: publicLoading,
+    error: publicError,
+  } = useGetUserPublicInfoByIdQuery({
+    variables: { getUserPublicInfoByIdId: userId! },
+    skip:
+      !userId || typeof userId !== 'string' || isOwner || currentUserId === null,
   });
+
+  const {
+    data: privateData,
+    loading: privateLoading,
+    error: privateError,
+  } = useGetUserPrivateInfoByIdQuery({
+    variables: { getUserPrivateInfoByIdId: userId! },
+    skip:
+      !userId || typeof userId !== 'string' || !isOwner || currentUserId === null,
+  });
+
+  const loading = publicLoading || privateLoading || currentUserId === null;
+  const error = publicError || privateError;
+  const userData = isOwner
+    ? privateData?.getUserPrivateInfoById
+    : publicData?.getUserPublicInfoById;
 
   if (loading) {
     return (
@@ -27,11 +61,11 @@ export default function UserProfilePage() {
     );
   }
 
-  if (!userId || !data?.getUserById || error) {
+  if (!userId || !userData || error) {
     return notFound();
   }
 
-  const user: Users = data.getUserById as Users;
+  const user: Users = userData as Users;
 
   return (
     <div className="min-h-screen bg-background text-foreground">

--- a/src/graphql/all.graphql
+++ b/src/graphql/all.graphql
@@ -48,11 +48,83 @@ query CurrentUser {
   }
 }
 
-query GetUserById($getUserByIdId: ID!) {
-  getUserById(id: $getUserByIdId) {
+query GetUserPublicInfoById($getUserPublicInfoByIdId: ID!) {
+  getUserPublicInfoById(id: $getUserPublicInfoByIdId) {
+    id
+    firstName
+    lastName
+    profileImageUrl
+    bio
+    city
+    state
+    country
+    availableNow
+    isHelper
+    isTaskPoster
+    maxTravelDistance
+    preferredCategories
+    postedTasks {
+      id
+      title
+      description
+      isRemote
+      address
+      estimatedDuration
+      paymentAmount
+      isUrgent
+      createdAt
+    }
+    taskApplications {
+      id
+      appliedAt
+      respondedAt
+      status
+      task {
+        id
+        posterId
+        title
+        paymentAmount
+        posterRating
+        helperRating
+        posterFeedback
+        helperFeedback
+        estimatedDuration
+        categoryId
+        createdAt
+        poster {
+          id
+          firstName
+          lastName
+          profileImageUrl
+        }
+      }
+      helper {
+        id
+        firstName
+        lastName
+        profileImageUrl
+      }
+    }
+    helperRating
+    helperRatingCount
+    posterRating
+    posterRatingCount
+    tasksCompleted
+    tasksPosted
+    emailVerified
+    phoneVerified
+    backgroundCheckStatus
+    accountStatus
+    createdAt
+    updatedAt
+    lastActiveAt
+  }
+}
+
+query GetUserPrivateInfoById($getUserPrivateInfoByIdId: ID!) {
+  getUserPrivateInfoById(id: $getUserPrivateInfoByIdId) {
     id
     email
-    passwordHash
     firstName
     lastName
     phone
@@ -73,123 +145,51 @@ query GetUserById($getUserByIdId: ID!) {
     preferredCategories
     postedTasks {
       id
-      posterId
-      categoryId
       title
       description
-      requirements
       isRemote
       address
-      city
-      state
-      zipCode
-      latitude
-      longitude
       estimatedDuration
       paymentAmount
       isUrgent
-      urgencyFee
-      status
-      assignedTo
-      startedAt
-      completedAt
-      dueDate
-      maxApplications
-      autoAssign
-      helperRating
-      posterRating
-      helperFeedback
-      posterFeedback
       createdAt
-      updatedAt
+    }
+    taskApplications {
+      id
+      appliedAt
+      respondedAt
+      status
+      task {
+        id
+        posterId
+        title
+        paymentAmount
+        posterRating
+        helperRating
+        posterFeedback
+        helperFeedback
+        estimatedDuration
+        categoryId
+        createdAt
+        poster {
+          id
+          firstName
+          lastName
+          profileImageUrl
+        }
+      }
+      helper {
+        id
+        firstName
+        lastName
+        profileImageUrl
+      }
     }
     helperRating
     helperRatingCount
     posterRating
     posterRatingCount
     tasksCompleted
-    taskApplications {
-      id
-      taskId
-
-      helperId
-      message
-      proposedStartTime
-      estimatedCompletionTime
-      status
-      appliedAt
-      respondedAt
-      task {
-        id
-        posterId
-        categoryId
-        title
-        description
-        requirements
-        isRemote
-        address
-        city
-        state
-        zipCode
-        latitude
-        longitude
-        estimatedDuration
-        paymentAmount
-        isUrgent
-        urgencyFee
-        status
-        assignedTo
-        startedAt
-        completedAt
-        dueDate
-        maxApplications
-        autoAssign
-        helperRating
-        posterRating
-        helperFeedback
-        posterFeedback
-        createdAt
-        updatedAt
-        poster {
-          id
-          email
-          passwordHash
-          firstName
-          lastName
-          phone
-          profileImageUrl
-          bio
-          dateOfBirth
-          address
-          city
-          state
-          country
-          zipCode
-          latitude
-          longitude
-          isHelper
-          isTaskPoster
-          availableNow
-          maxTravelDistance
-          preferredCategories
-          helperRating
-          helperRatingCount
-          posterRating
-          posterRatingCount
-          tasksCompleted
-          tasksPosted
-          totalEarned
-          totalSpent
-          emailVerified
-          phoneVerified
-          backgroundCheckStatus
-          accountStatus
-          createdAt
-          updatedAt
-          lastActiveAt
-        }
-      }
-    }
     tasksPosted
     totalEarned
     totalSpent


### PR DESCRIPTION
## Summary
- separate user profile query into public and private variants
- switch profile page to select appropriate query based on owner

## Testing
- `NODE_ENV=production npm run build` *(fails: connect ENETUNREACH 216.24.57.7:443)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ad88a570832097c95c81b38fdfc0